### PR TITLE
Expose segmented thoughts

### DIFF
--- a/DimonSmart.AiUtils.Tests/ContentParserTests.cs
+++ b/DimonSmart.AiUtils.Tests/ContentParserTests.cs
@@ -13,6 +13,7 @@
 
             // Assert
             Assert.Equal("This is a thought", result.Thoughts);
+            Assert.Equal(new[] { "This is a thought" }, result.ThoughtSegments);
             Assert.Equal("Before text after text.", result.Answer);
         }
 
@@ -27,6 +28,7 @@
 
             // Assert
             Assert.Equal(string.Empty, result.Thoughts);
+            Assert.Empty(result.ThoughtSegments);
             Assert.Equal("Text without think tag.", result.Answer);
         }
 
@@ -41,6 +43,7 @@
 
             // Assert
             Assert.Equal("First thought\nSecond thought", result.Thoughts);
+            Assert.Equal(new[] { "First thought", "Second thought" }, result.ThoughtSegments);
             Assert.Equal("Start middle end.", result.Answer);
         }
     }

--- a/DimonSmart.AiUtils.Tests/FuzzyJsonExtractorTests.cs
+++ b/DimonSmart.AiUtils.Tests/FuzzyJsonExtractorTests.cs
@@ -10,7 +10,7 @@ namespace DimonSmart.AiUtils.Tests
 
         [Fact(Skip = "Manual Research")]
         [Trait("Category", "Manual")]
-        
+
         public void FuzzyTest_ExtractJson()
         {
             for (var iteration = 0; iteration < 100000; iteration++)

--- a/DimonSmart.AiUtils/ThinkTagParser.cs
+++ b/DimonSmart.AiUtils/ThinkTagParser.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.RegularExpressions;
-using System.Collections.Generic;
 
 namespace DimonSmart.AiUtils
 {

--- a/DimonSmart.AiUtils/ThinkTagParser.cs
+++ b/DimonSmart.AiUtils/ThinkTagParser.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using System.Collections.Generic;
 
 namespace DimonSmart.AiUtils
 {
@@ -31,6 +32,11 @@ namespace DimonSmart.AiUtils
             /// Gets the combined thought content joined by newline.
             /// </summary>
             public string Thoughts => string.Join("\n", _thoughtSegments);
+
+            /// <summary>
+            /// Gets the individual thought segments as an immutable list.
+            /// </summary>
+            public IReadOnlyList<string> ThoughtSegments => _thoughtSegments;
 
             /// <summary>
             /// Gets the combined answer text joined by newline.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ Extracts and separates content within `<think>` tags from the main response text
 
 ```csharp
 var result = ThinkTagParser.ExtractThinkAnswer(responseText);
-string thoughts = result.Thoughts;    // Combined content from all <think> tags
-string answer = result.Answer;        // Clean text without the think tags
+string thoughts = result.Thoughts;            // Combined content from all <think> tags
+var segments = result.ThoughtSegments;        // Individual thought segments
+string answer = result.Answer;                // Clean text without the think tags
 ```
 
 Example:
@@ -56,6 +57,7 @@ Example:
 var input = "Let me think about this. <think>First consider option A</think> The answer is B <think>Option B is better because...</think>";
 var result = ThinkTagParser.ExtractThinkAnswer(input);
 // result.Thoughts contains: "First consider option A\nOption B is better because..."
+// result.ThoughtSegments == ["First consider option A", "Option B is better because..."]
 // result.Answer contains: "Let me think about this. The answer is B"
 ```
 


### PR DESCRIPTION
## Summary
- expose individual thought segments in `ThinkTagParser`
- test the `ThoughtSegments` property
- document new `ThoughtSegments` property in README

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f4ae3e8c832a98928664e3a66199